### PR TITLE
Add Power ppc64le platform support

### DIFF
--- a/include/ob_object.h
+++ b/include/ob_object.h
@@ -87,6 +87,10 @@ typedef enum enum_obobjtype
   ObMaxType                 // invalid type, or count of obj type
 } ObObjType;
 
+/* add typedef for enum to avoid multiple definition of ObCollationType issue on powerpc64 ppc64le */
+#if defined(__powerpc64__)
+ typedef
+#endif
 enum enum_obcollationtype
 {
   CS_TYPE_INVALID = 0,
@@ -104,6 +108,10 @@ enum enum_obcollationtype
   CS_TYPE_MAX,
 } ObCollationType;
 
+/* add typedef for enum to avoid multiple definition of ObCollationLevel issue on powerpc64 ppc64le */
+#if defined(__powerpc64__)
+ typedef
+#endif
 enum enum_obcollationlevel
 {
   CS_LEVEL_EXPLICIT = 0,


### PR DESCRIPTION
Update ob_object.h.
add typedef for enum to avoid multiple definition of ObCollationType & ObCollationLevel issue on powerpc64 ppc64le

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
